### PR TITLE
Allow the user to specific an extra bank file and approximant

### DIFF
--- a/tools/einsteinathome/pycbc_build_eah.sh
+++ b/tools/einsteinathome/pycbc_build_eah.sh
@@ -1081,7 +1081,9 @@ for bank_file in $extra_bank $p
 do
   for inspiral_approx in "$extra_approx" $gw150914_approx
   do
+    if ! test -z $inspiral_approx && ! test -z $bank_file ; then
     rm -f H1-INSPIRAL-OUT.hdf
+    echo -e "\\n\\n>> [`date`] pycbc_inspiral using $bank_file with $extra_approx"
     LAL_DATA_PATH="." \
       NO_TMPDIR=1 \
       INITIAL_LOG_LEVEL=10 \
@@ -1122,6 +1124,7 @@ do
       --frame-files "$f" \
       --bank-file "$bank_file" \
       --verbose 2>&1
+      fi
   done
 done
 

--- a/tools/einsteinathome/pycbc_build_eah.sh
+++ b/tools/einsteinathome/pycbc_build_eah.sh
@@ -249,7 +249,7 @@ if [ ".$link_gcc_version" != "." ]; then
 fi
 libgfortran_dir="`$FC -print-file-name=$libgfortran|sed 's%/[^/]*$%%'`"
 export LD_LIBRARY_PATH="$PREFIX/lib:$PREFIX/bin:$PYTHON_PREFIX/lib:$libgfortran_dir:/usr/local/lib:$LD_LIBRARY_PATH"
-export CPPFLAGS="-I$PREFIX/include -I$PYTHON_PREFIX/include $CPPFLAGS"
+export CPPFLAGS="-I$PREFIX/include -I$PREFIX/dist/pycbc_inspiral/include -I$PYTHON_PREFIX/include $CPPFLAGS"
 export PKG_CONFIG_PATH="$PREFIX/lib/pkgconfig:$PYTHON_PREFIX/lib/pkgconfig:/usr/local/lib/pkgconfig:$PKG_CONFIG_PATH"
 export LIBS="$LIBS -lgfortran"
 

--- a/tools/einsteinathome/pycbc_build_eah.sh
+++ b/tools/einsteinathome/pycbc_build_eah.sh
@@ -1083,7 +1083,7 @@ do
   do
     if ! test -z $inspiral_approx && ! test -z $bank_file ; then
     rm -f H1-INSPIRAL-OUT.hdf
-    echo -e "\\n\\n>> [`date`] pycbc_inspiral using $bank_file with $extra_approx"
+    echo -e "\\n\\n>> [`date`] pycbc_inspiral using --bank-file $bank_file --approximant $inspiral_approx"
     LAL_DATA_PATH="." \
       NO_TMPDIR=1 \
       INITIAL_LOG_LEVEL=10 \

--- a/tools/einsteinathome/pycbc_build_eah.sh
+++ b/tools/einsteinathome/pycbc_build_eah.sh
@@ -1092,6 +1092,8 @@ if ! test -z "$extra_approx" || ! test -z "$extra_bank" ; then
     fi
 fi
 
+n_runs=${#bank_array[@]}
+
 for (( i=0; i<${n_runs}; i++ ))
 do
     rm -f H1-INSPIRAL-OUT.hdf

--- a/tools/einsteinathome/pycbc_build_eah.sh
+++ b/tools/einsteinathome/pycbc_build_eah.sh
@@ -249,7 +249,7 @@ if [ ".$link_gcc_version" != "." ]; then
 fi
 libgfortran_dir="`$FC -print-file-name=$libgfortran|sed 's%/[^/]*$%%'`"
 export LD_LIBRARY_PATH="$PREFIX/lib:$PREFIX/bin:$PYTHON_PREFIX/lib:$libgfortran_dir:/usr/local/lib:$LD_LIBRARY_PATH"
-export CPPFLAGS="-I$PREFIX/include -I$PREFIX/dist/pycbc_inspiral/include -I$PYTHON_PREFIX/include $CPPFLAGS"
+export CPPFLAGS="-I$PREFIX/include -I$PYTHON_PREFIX/include/python2.7 -I$PYTHON_PREFIX/include $CPPFLAGS"
 export PKG_CONFIG_PATH="$PREFIX/lib/pkgconfig:$PYTHON_PREFIX/lib/pkgconfig:/usr/local/lib/pkgconfig:$PKG_CONFIG_PATH"
 export LIBS="$LIBS -lgfortran"
 

--- a/tools/einsteinathome/pycbc_build_eah.sh
+++ b/tools/einsteinathome/pycbc_build_eah.sh
@@ -36,6 +36,7 @@ libgfortran=libgfortran.so
 extra_libs=""
 extra_bank=""
 extra_approx=""
+lal_data_path="."
 
 # defaults, possibly overwritten by OS-specific settings
 build_gcc=false
@@ -194,6 +195,7 @@ usage="
     --with-extra-libs=<url> : add extra files from a tar file at <url> to the bundles
     --with-extra-bank=<file> : run pycbc_inspiral again with an extra template bank
     --with-extra-approx=<file> : run pycbc_inspiral again with an extra approximant
+    --with-lal-data=<path> : run test job using ROM data from <path>
     --verbose-python  : run PyInstalled Python in verbose mode, showing imports
     --no-analysis     : for testing, don't run analysis, assume weave cache is already there
 "
@@ -234,6 +236,7 @@ for i in $*; do
         --with-extra-libs=*) extra_libs="`echo $i|sed 's/^--with-extra-libs=//'`";;
         --with-extra-bank=*) extra_bank="`echo $i|sed 's/^--with-extra-bank=//'`";;
         --with-extra-approx=*) extra_approx="${extra_approx}`echo $i|sed 's/^--with-extra-approx=//'` ";;
+        --with-lal-data=*) lal_data_path="`echo $i|sed 's/^--with-lal-data=//'`";;
         --help) echo -e "Options:\n$usage">&2; exit 0;;
         *) echo -e "unknown option '$i', valid are:\n$usage">&2; exit 1;;
     esac
@@ -1098,7 +1101,8 @@ for (( i=0; i<${n_runs}; i++ ))
 do
     rm -f H1-INSPIRAL-OUT.hdf
     echo -e "\\n\\n>> [`date`] pycbc_inspiral using --bank-file ${bank_array[$i]} --approximant ${approx_array[$i]}"
-    LAL_DATA_PATH="." \
+    echo -e "\\n\\n>> [`date`] pycbc_inspiral using ROM data from $lal_data_path"
+    LAL_DATA_PATH="$lal_data_path" \
       NO_TMPDIR=1 \
       INITIAL_LOG_LEVEL=10 \
       LEVEL2_CACHE_SIZE=8192 \


### PR DESCRIPTION
Some applications may need to weave compile different code paths to the GW150914 analysis (for example, the waveform compression that @soumide1102 and @ahnitz are working on). This patch allows ``pycbc_inspiral`` to be called multiple times with different bank files and approximants to trigger weave compilation of the different code paths. The standard GW150914 test is called last, so that @bema-ligo's check on the results still works.