### PR TITLE
Add additional CPPFLAG to fix weave build issues

### DIFF
--- a/tools/einsteinathome/pycbc_build_eah.sh
+++ b/tools/einsteinathome/pycbc_build_eah.sh
@@ -249,7 +249,7 @@ if [ ".$link_gcc_version" != "." ]; then
 fi
 libgfortran_dir="`$FC -print-file-name=$libgfortran|sed 's%/[^/]*$%%'`"
 export LD_LIBRARY_PATH="$PREFIX/lib:$PREFIX/bin:$PYTHON_PREFIX/lib:$libgfortran_dir:/usr/local/lib:$LD_LIBRARY_PATH"
-export CPPFLAGS="-I$PREFIX/include -I$PYTHON_PREFIX/include $CPPFLAGS"
+export CPPFLAGS="-I$PREFIX/include -I$PREFIX/dist/pycbc_inspiral/include -I$PYTHON_PREFIX/include $CPPFLAGS"
 export PKG_CONFIG_PATH="$PREFIX/lib/pkgconfig:$PYTHON_PREFIX/lib/pkgconfig:/usr/local/lib/pkgconfig:$PKG_CONFIG_PATH"
 export LIBS="$LIBS -lgfortran"
 

--- a/tools/einsteinathome/pycbc_build_eah.sh
+++ b/tools/einsteinathome/pycbc_build_eah.sh
@@ -249,7 +249,7 @@ if [ ".$link_gcc_version" != "." ]; then
 fi
 libgfortran_dir="`$FC -print-file-name=$libgfortran|sed 's%/[^/]*$%%'`"
 export LD_LIBRARY_PATH="$PREFIX/lib:$PREFIX/bin:$PYTHON_PREFIX/lib:$libgfortran_dir:/usr/local/lib:$LD_LIBRARY_PATH"
-export CPPFLAGS="-I$PREFIX/include -I$PREFIX/dist/pycbc_inspiral/include -I$PYTHON_PREFIX/include $CPPFLAGS"
+export CPPFLAGS="-I$PREFIX/include -I$PYTHON_PREFIX/include/python2.7 -I$PYTHON_PREFIX/include $CPPFLAGS"
 export PKG_CONFIG_PATH="$PREFIX/lib/pkgconfig:$PYTHON_PREFIX/lib/pkgconfig:/usr/local/lib/pkgconfig:$PKG_CONFIG_PATH"
 export LIBS="$LIBS -lgfortran"
 


### PR DESCRIPTION
When testing the current master on RH6, ``pycbc_inspiral`` can't weave-compile its code fragments. The first weave compile hits the error:
```
2017-01-31 08:32:08,092 attempting to aquire lock '/home/dbrown/projects/pycbc/eah/pycbc-sources/test/pycbc_inspiral/code_lockfile' for compiling code
2017-01-31 08:32:08,097 we have aquired the lock
In file included from /home/dbrown/projects/pycbc/eah/pycbc-build/environment/dist/pycbc_inspiral/scipy/weave/scxx/weave_imp.cpp:7:
/home/dbrown/projects/pycbc/eah/pycbc-build/environment/dist/pycbc_inspiral/scipy/weave/scxx/object.h:11:20: error: Python.h: No such file or directory
```
(extraneous cruft omitted)
```
scipy.weave.build_tools.CompileError: error: Command "g++ -fno-strict-aliasing -g -O2 -DNDEBUG -g -fwrapv -O3 -Wall -I/home/dbrown/projects/pycbc/eah/pycbc-build/environment/include -I/home/dbrown/projects/pycbc/eah/pycbc-build/include -fPIC -I/home/dbrown/projects/pycbc/eah/pycbc-build/environment/dist/pycbc_inspiral/scipy/weave -I/home/dbrown/projects/pycbc/eah/pycbc-build/environment/dist/pycbc_inspiral/scipy/weave/scxx -I/home/dbrown/projects/pycbc/eah/pycbc-build/environment/dist/pycbc_inspiral/numpy/core/include -I/home/dbrown/projects/pycbc/eah/pycbc-build/environment/dist/pycbc_inspiral/include/python2.7 -c /home/dbrown/projects/pycbc/eah/pycbc-build/environment/dist/pycbc_inspiral/scipy/weave/scxx/weave_imp.cpp -o /tmp/scipy-dbrown-I16bSL/python27_intermediate/compiler_7ec009847f0362ac1de17d17f6eaefdf/home/dbrown/projects/pycbc/eah/pycbc-build/environment/dist/pycbc_inspiral/scipy/weave/scxx/weave_imp.o -O3 -march=core2 -w -fopenmp" failed with exit status 1
```
It appears that the ``Python.h`` header file can't be found in the includes that weave is using. In my build it is available here:
```
[dbrown@sugwg-dev1 eah]$ find . -name Python.h
./pycbc-build/environment/dist/pycbc_inspiral/include/Python.h
./pycbc-build/include/python2.7/Python.h
```
so this adds an extra ``CPPFLAGS`` to find it in ``pycbc-build/environment/dist/pycbc_inspiral/include``. 